### PR TITLE
fix: make typescript peer optional and relax range (>=5.0.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,12 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^6.0.2"
+    "typescript": ">=5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@electron-webauthn/types": "^1.3.0"


### PR DESCRIPTION
Fixes #7.

## Problem

`typescript` is declared as a **required** peer dependency pinned to `^6.0.2`. Any consumer not on TypeScript 6.x fails to install:

```
npm error ERESOLVE unable to resolve dependency tree
npm error peer typescript@"^6.0.2" from electron-webauthn@1.3.1
npm error Found: typescript@4.5.5
```

TypeScript is needed neither at install nor at runtime — the package ships compiled JS (`dist/index.js`), and the bundled `.d.ts` uses only basic declaration syntax (verified to type-check under TS 4.5 with `skipLibCheck`). The `^6.0.2` peer effectively tracks the version TS was built with (history: none → `^5` → `^6.0.2`) rather than a real minimum.

## Change

```diff
- "peerDependencies": { "typescript": "^6.0.2" }
+ "peerDependencies": { "typescript": ">=5.0.0" },
+ "peerDependenciesMeta": { "typescript": { "optional": true } }
```

- **`optional: true`** stops the peer from breaking `npm install` for consumers who don't have (or don't need) TypeScript — this is the key fix.
- **`>=5.0.0`** relaxes the caret pin to a lower bound, so newer TS releases keep satisfying it without further bumps.

This matches common practice for type-shipping packages: many declare no `typescript` peer at all (zod, type-fest, drizzle-orm, @trpc/server), and those that do mark it optional with a `>=` bound (valibot `>=5` optional, ts-essentials `>=4.5.0` optional).

No runtime or API changes.
