### PR TITLE
fix(macos): security-key clientDataHash, raw authData, PRF guard, fail-closed config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -14,8 +14,11 @@
         "@electron-webauthn/macos": "^1.3.0",
       },
       "peerDependencies": {
-        "typescript": "^6.0.2",
+        "typescript": "^5.0.0",
       },
+      "optionalPeers": [
+        "typescript",
+      ],
     },
     "packages/macos": {
       "name": "@electron-webauthn/macos",
@@ -31,8 +34,11 @@
         "objcjs-types": "0.8.0",
       },
       "peerDependencies": {
-        "typescript": "^6.0.2",
+        "typescript": "^5.0.0",
       },
+      "optionalPeers": [
+        "typescript",
+      ],
     },
     "packages/types": {
       "name": "@electron-webauthn/types",

--- a/bun.lock
+++ b/bun.lock
@@ -19,9 +19,10 @@
     },
     "packages/macos": {
       "name": "@electron-webauthn/macos",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "dependencies": {
         "@electron-webauthn/types": "^1.2.0",
+        "@oslojs/cbor": "^1.0.0",
         "@oslojs/webauthn": "^1.0.0",
         "objc-js": "^1.5.0",
       },
@@ -35,7 +36,7 @@
     },
     "packages/types": {
       "name": "@electron-webauthn/types",
-      "version": "1.3.0",
+      "version": "1.3.1",
     },
   },
   "trustedDependencies": [
@@ -58,11 +59,11 @@
 
     "@oslojs/webauthn": ["@oslojs/webauthn@1.0.0", "", { "dependencies": { "@oslojs/asn1": "1.0.0", "@oslojs/binary": "1.0.0", "@oslojs/cbor": "1.0.0", "@oslojs/crypto": "1.0.0", "@oslojs/encoding": "1.0.0" } }, "sha512-2ZRpbt3msNURwvjmavzq9vrNlxUnWFBGMYqbC1kO3fYBLskL7r4DiLJT1wbtLoI+hclFwjhl48YhRFBl6RWg1A=="],
 
-    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/node": ["@types/node@25.5.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg=="],
 
-    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "node-addon-api": ["node-addon-api@8.7.0", "", {}, "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA=="],
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,12 @@
     "@types/bun": "latest"
   },
   "peerDependencies": {
-    "typescript": "^6.0.2"
+    "typescript": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@electron-webauthn/types": "^1.3.0"

--- a/packages/macos/package.json
+++ b/packages/macos/package.json
@@ -33,7 +33,12 @@
     "objcjs-types": "0.8.0"
   },
   "peerDependencies": {
-    "typescript": "^6.0.2"
+    "typescript": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@electron-webauthn/types": "^1.2.0",

--- a/packages/macos/package.json
+++ b/packages/macos/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@electron-webauthn/types": "^1.2.0",
+    "@oslojs/cbor": "^1.0.0",
     "@oslojs/webauthn": "^1.0.0",
     "objc-js": "^1.5.0"
   },

--- a/packages/macos/src/create/authorization-controller.ts
+++ b/packages/macos/src/create/authorization-controller.ts
@@ -6,10 +6,15 @@ import { NSArrayFromObjects, NSStringFromString } from "objcjs-types/helpers";
 import { NSNumber } from "objcjs-types/Foundation";
 import { ASCPublicKeyCredentialDescriptor } from "../additional-objc/ASCPublicKeyCredentialDescriptor.js";
 
-const createControllerState = new Map<
-  string,
-  [Buffer, PublicKeyCredentialParams[], boolean, ExcludeCredential[]]
->();
+interface CreateControllerState {
+  clientDataHash: Buffer;
+  pubKeyCredParams: PublicKeyCredentialParams[];
+  residentKeyRequired: boolean;
+  excludeCredentials: ExcludeCredential[];
+  onConfigurationError: (error: unknown) => void;
+}
+
+const createControllerState = new Map<string, CreateControllerState>();
 
 function getObjectPointerString(self: NobjcObject) {
   return getPointer(self).toString("base64");
@@ -25,15 +30,17 @@ export function setControllerState(
   clientDataHash: Buffer,
   pubKeyCredParams: PublicKeyCredentialParams[],
   residentKeyRequired: boolean,
-  excludeCredentialIds: ExcludeCredential[]
+  excludeCredentials: ExcludeCredential[],
+  onConfigurationError: (error: unknown) => void
 ) {
   const selfPointer = getObjectPointerString(self);
-  createControllerState.set(selfPointer, [
+  createControllerState.set(selfPointer, {
     clientDataHash,
     pubKeyCredParams,
     residentKeyRequired,
-    excludeCredentialIds,
-  ]);
+    excludeCredentials,
+    onConfigurationError,
+  });
 }
 
 export function removeControllerState(self: NobjcObject) {
@@ -41,11 +48,80 @@ export function removeControllerState(self: NobjcObject) {
   createControllerState.delete(selfPointer);
 }
 
+// Mutate a single registration-options object in place: client data hash, challenge
+// null-out, supported algorithms, resident-key requirement (platform only), and excluded
+// credentials. `isSecurityKey` suppresses the resident-key setter (see note below).
+function applyCreateOptions(
+  registrationOptions: NobjcObject,
+  isSecurityKey: boolean,
+  clientDataHash: Buffer,
+  pubKeyCredParams: PublicKeyCredentialParams[],
+  residentKeyRequired: boolean,
+  excludeCredentials: ExcludeCredential[]
+) {
+  registrationOptions.setClientDataHash$(NSDataFromBuffer(clientDataHash));
+  registrationOptions.setChallenge$(null);
+
+  // Set supported algorithm identifiers
+  const supportedAlgos: NobjcObject[] = [];
+  for (const param of pubKeyCredParams) {
+    if (param.type === "public-key") {
+      const nsNum = NSNumber.numberWithInteger$(param.algorithm);
+      supportedAlgos.push(nsNum);
+    }
+  }
+  if (supportedAlgos.length > 0) {
+    registrationOptions.setSupportedAlgorithmIdentifiers$(
+      NSArrayFromObjects(supportedAlgos as unknown as NobjcObject[])
+    );
+  }
+
+  // Set resident key requirement
+  // If this is enabled for security keys, users will not be able to scan QR code to register a new credential.
+  if (!isSecurityKey) {
+    registrationOptions.setShouldRequireResidentKey$(residentKeyRequired);
+  }
+
+  // Set excluded credentials
+  const excludeList: NobjcObject[] = [];
+  for (const cred of excludeCredentials) {
+    // Convert transports to NSArray of NSString
+    const transports: NobjcObject[] = [];
+    if (cred.transports) {
+      for (const transport of cred.transports) {
+        transports.push(NSStringFromString(transport));
+      }
+    }
+
+    // Create descriptor
+    const credentialID = NSDataFromBuffer(cred.id);
+    const transportsArray = NSArrayFromObjects(transports);
+
+    // ASCPublicKeyCredentialDescriptor is a private class!
+    const initializedDescriptor =
+      ASCPublicKeyCredentialDescriptor.alloc().initWithCredentialID$transports$(
+        credentialID,
+        transportsArray
+      );
+    excludeList.push(initializedDescriptor);
+  }
+  if (excludeList.length > 0) {
+    registrationOptions.setExcludedCredentials$(
+      NSArrayFromObjects(excludeList)
+    );
+  }
+}
+
 export const WebauthnCreateController = NobjcClass.define({
   name: "WebauthnCreateController",
   superclass: "ASAuthorizationController",
   methods: {
-    // This overrides the default implementation of _requestContextWithRequests$error$ to allow us to set the clientDataHash on the assertion options
+    // Overrides _requestContextWithRequests$error$ to inject our clientDataHash (and a few
+    // other private fields) into BOTH platform and security-key registration options. The
+    // previous implementation only handled whichever of the two existed (platform first,
+    // security-key as a fallback), so when attachment:"all" submitted both requests the
+    // security-key request kept Apple's default hash and signed a different clientDataJSON
+    // than the one we returned to the page -> relying-party verification failed.
     _requestContextWithRequests$error$: {
       types: "@@:@^@",
       implementation: (self: any, requests: any, outError: any) => {
@@ -56,80 +132,48 @@ export const WebauthnCreateController = NobjcClass.define({
           outError
         );
 
-        // Grab the registration options, set the client data hash, and set a copy of the registration options back on the context
         const selfPointer = getObjectPointerString(self);
-        if (context && createControllerState.has(selfPointer)) {
-          let isSecurityKey = false;
-
-          let registrationOptions =
-            context.platformKeyCredentialCreationOptions();
-          if (!registrationOptions) {
-            registrationOptions =
-              context.securityKeyCredentialCreationOptions();
-            isSecurityKey = true;
-          }
-
-          const [
+        const state = createControllerState.get(selfPointer);
+        if (context && state) {
+          const {
             clientDataHash,
             pubKeyCredParams,
             residentKeyRequired,
             excludeCredentials,
-          ] = createControllerState.get(selfPointer);
+            onConfigurationError,
+          } = state;
 
-          registrationOptions.setClientDataHash$(
-            NSDataFromBuffer(clientDataHash)
-          );
-          registrationOptions.setChallenge$(null);
-
-          // Set supported algorithm identifiers
-          const supportedAlgos: NobjcObject[] = [];
-          for (const param of pubKeyCredParams) {
-            if (param.type === "public-key") {
-              const nsNum = NSNumber.numberWithInteger$(param.algorithm);
-              supportedAlgos.push(nsNum);
-            }
-          }
-          if (supportedAlgos.length > 0) {
-            registrationOptions.setSupportedAlgorithmIdentifiers$(
-              NSArrayFromObjects(supportedAlgos as unknown as NobjcObject[])
-            );
-          }
-
-          // Set resident key requirement
-          // If this is enabled for security keys, users will not be able to scan QR code to register a new credential.
-          if (!isSecurityKey) {
-            registrationOptions.setShouldRequireResidentKey$(
-              residentKeyRequired
-            );
-          }
-
-          // Set excluded credentials
-          const excludeList: NobjcObject[] = [];
-          for (const cred of excludeCredentials) {
-            // Convert transports to NSArray of NSString
-            const transports: NobjcObject[] = [];
-            if (cred.transports) {
-              for (const transport of cred.transports) {
-                transports.push(NSStringFromString(transport));
-              }
-            }
-
-            // Create descriptor
-            const credentialID = NSDataFromBuffer(cred.id);
-            const transportsArray = NSArrayFromObjects(transports);
-
-            // ASCPublicKeyCredentialDescriptor is a private class!
-            const initializedDescriptor =
-              ASCPublicKeyCredentialDescriptor.alloc().initWithCredentialID$transports$(
-                credentialID,
-                transportsArray
+          try {
+            const platformOptions =
+              context.platformKeyCredentialCreationOptions();
+            if (platformOptions) {
+              applyCreateOptions(
+                platformOptions,
+                false,
+                clientDataHash,
+                pubKeyCredParams,
+                residentKeyRequired,
+                excludeCredentials
               );
-            excludeList.push(initializedDescriptor);
-          }
-          if (excludeList.length > 0) {
-            registrationOptions.setExcludedCredentials$(
-              NSArrayFromObjects(excludeList)
-            );
+            }
+
+            // Mirror the injection on the security-key options. These are private selectors,
+            // so the whole ceremony fails closed if this macOS version does not provide every
+            // setter rather than leaving a partially configured request active.
+            const securityKeyOptions =
+              context.securityKeyCredentialCreationOptions();
+            if (securityKeyOptions) {
+              applyCreateOptions(
+                securityKeyOptions,
+                true,
+                clientDataHash,
+                pubKeyCredParams,
+                residentKeyRequired,
+                excludeCredentials
+              );
+            }
+          } catch (error) {
+            onConfigurationError(error);
           }
         }
 

--- a/packages/macos/src/create/handler.ts
+++ b/packages/macos/src/create/handler.ts
@@ -87,7 +87,7 @@ export async function createCredential(
 ): Promise<CreateCredentialResult> {
   // Check all the arguments
   if (!publicKeyOptions) {
-    return null;
+    return { success: false, error: "TypeError" };
   }
 
   const rpInfo = publicKeyOptions.rp;
@@ -247,6 +247,7 @@ export async function createCredential(
     userVerificationPreference,
     {
       topFrameOrigin,
+      userDisplayName,
       largeBlobSupport,
       prf,
     }
@@ -261,6 +262,7 @@ export async function createCredential(
 
   const data: CreateCredentialSuccessData = {
     credentialId: bufferToBase64Url(result.credentialId),
+    authenticatorAttachment: result.attachment,
     clientDataJSON: bufferToBase64Url(result.clientDataJSON),
     attestationObject: bufferToBase64Url(result.attestationObject),
     authData: bufferToBase64Url(result.authenticatorData),

--- a/packages/macos/src/create/handler.ts
+++ b/packages/macos/src/create/handler.ts
@@ -2,7 +2,12 @@ import type { UserVerificationPreference } from "../get/internal-handler.js";
 import { bufferSourceToBuffer, bufferToBase64Url } from "../helpers/index.js";
 import type { PRFInput } from "../helpers/prf.js";
 import { isRpIdAllowedForOrigin } from "../helpers/rpid.js";
-import { isNumber, isObject, isString } from "../helpers/validation.js";
+import {
+  isNumber,
+  isObject,
+  isString,
+  mapNativeAuthorizationError,
+} from "../helpers/validation.js";
 import type {
   CreateCredentialResult,
   CreateCredentialSuccessData,
@@ -108,7 +113,7 @@ export async function createCredential(
     // 1 hour (max timeout)
     timeout = 60 * 60 * 1000;
   }
-  // TODO: Handle timeout
+  // Timeout is enforced inside createCredentialInternal and surfaces as NotAllowedError.
 
   const challenge = bufferSourceToBuffer(publicKeyOptions.challenge);
   if (!challenge) {
@@ -247,19 +252,7 @@ export async function createCredential(
     }
   ).catch((error: Error) => {
     errorResult = error;
-    // console.error("Error creating credential", error);
-    if (
-      error.message.includes(
-        "(com.apple.AuthenticationServices.AuthorizationError error 1006.)"
-      )
-    ) {
-      // MatchedExcludedCredential
-      return "InvalidStateError";
-    }
-    if (error.message.startsWith("The operation couldn’t be completed.")) {
-      return "NotAllowedError";
-    }
-    return null;
+    return mapNativeAuthorizationError(error);
   });
 
   if (typeof result === "string") {

--- a/packages/macos/src/create/internal-handler.ts
+++ b/packages/macos/src/create/internal-handler.ts
@@ -42,7 +42,7 @@ export interface CreateCredentialResult {
   attestationObject: Buffer;
   authenticatorData: Buffer;
   attachment: AuthenticatorAttachment;
-  transports: string[];
+  transports: AuthenticatorTransport[];
   isResidentKey: boolean;
   publicKeyAlgorithm: number;
   publicKey: Buffer;
@@ -351,100 +351,113 @@ function createCredentialInternal(
       _,
       authorization
     ) => {
-      const credential = authorization.credential();
-      console.log("Authorization succeeded:", credential);
+      // Wrapped in try/catch: without this, a parsing/encoding error below (e.g. an
+      // unsupported COSE key algorithm) would leave the returned promise pending
+      // forever, since neither resolve/reject nor finished() would otherwise run.
+      try {
+        const credential = authorization.credential();
 
-      const isPlatform =
-        credential instanceof
-        ASAuthorizationPlatformPublicKeyCredentialRegistration;
-      const isSecurityKey =
-        credential instanceof
-        ASAuthorizationSecurityKeyPublicKeyCredentialRegistration;
-      if (!isPlatform && !isSecurityKey) {
-        reject(
-          new Error(
-            "Resulting credential is not a platform or security key credential"
-          )
+        const isPlatform =
+          credential instanceof
+          ASAuthorizationPlatformPublicKeyCredentialRegistration;
+        const isSecurityKey =
+          credential instanceof
+          ASAuthorizationSecurityKeyPublicKeyCredentialRegistration;
+        if (!isPlatform && !isSecurityKey) {
+          reject(
+            new Error(
+              "Resulting credential is not a platform or security key credential"
+            )
+          );
+          finished(false);
+          return;
+        }
+
+        const credentialIdBuffer = bufferFromNSDataDirect(
+          credential.credentialID()
         );
+
+        const attestationObjectBuffer = bufferFromNSDataDirect(
+          credential.rawAttestationObject()
+        );
+        const attestation = parseAttestationObject(attestationObjectBuffer);
+
+        const publicKey = attestation.authenticatorData.credential.publicKey;
+
+        // Encode the public key to DER-encoded SubjectPublicKeyInfo (SPKI) format
+        const ec2Key = publicKey.ec2();
+        const publicKeySPKI = encodeEC2PublicKeyToSPKI(ec2Key.x, ec2Key.y);
+
+        // Must be the raw authData bytes (not the parsed object) - the relying
+        // party server re-verifies this exact byte sequence against the signature.
+        const authenticatorData = extractRawAuthenticatorData(
+          attestationObjectBuffer
+        );
+
+        let authenticatorAttachment: AuthenticatorAttachment =
+          "cross-platform";
+        if (
+          isPlatform &&
+          credential.attachment() ===
+            ASAuthorizationPublicKeyCredentialAttachment.Platform
+        ) {
+          authenticatorAttachment = "platform";
+        }
+
+        let isLargeBlobSupported: boolean | null = null;
+        if (enabledExtensions.includes("largeBlob")) {
+          const largeBlobOutput = credential.largeBlob();
+          if (largeBlobOutput) {
+            isLargeBlobSupported = largeBlobOutput.isSupported();
+          }
+        }
+
+        let prfFirst: Buffer | null = null;
+        let prfSecond: Buffer | null = null;
+        let isPRFSupported: boolean | null = null;
+        if (enabledExtensions.includes("prf")) {
+          const prfOutput = credential.prf();
+          if (prfOutput) {
+            const prfFirstData = prfOutput.first();
+            const prfSecondData = prfOutput.second();
+            if (prfFirstData) {
+              prfFirst = bufferFromNSDataDirect(prfFirstData);
+            }
+            if (prfSecondData) {
+              prfSecond = bufferFromNSDataDirect(prfSecondData);
+            }
+
+            isPRFSupported = prfOutput.isSupported();
+          }
+        }
+
+        // Apple platform authenticators (Touch ID/Face ID) always create discoverable
+        // (resident) passkeys; for security keys we can only report back what we asked for,
+        // since the API doesn't expose whether the authenticator actually honored it.
+        const isResidentKey = isPlatform || residentKeyRequired;
+
+        const data: CreateCredentialResult = {
+          credentialId: credentialIdBuffer,
+          clientDataJSON: clientDataBuffer,
+          attestationObject: attestationObjectBuffer,
+          authenticatorData,
+          attachment: authenticatorAttachment,
+          transports: authenticatorAttachment === "platform" ? ["internal"] : [],
+          isResidentKey,
+          publicKeyAlgorithm: publicKey.algorithm(),
+          publicKey: publicKeySPKI,
+          isLargeBlobSupported,
+          isPRFSupported,
+          prfFirst,
+          prfSecond,
+        };
+        resolve(data);
+
+        finished(true);
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
         finished(false);
-        return;
       }
-
-      const credentialIdBuffer = bufferFromNSDataDirect(
-        credential.credentialID()
-      );
-
-      const attestationObjectBuffer = bufferFromNSDataDirect(
-        credential.rawAttestationObject()
-      );
-      const attestation = parseAttestationObject(attestationObjectBuffer);
-
-      const publicKey = attestation.authenticatorData.credential.publicKey;
-
-      // Encode the public key to DER-encoded SubjectPublicKeyInfo (SPKI) format
-      const ec2Key = publicKey.ec2();
-      const publicKeySPKI = encodeEC2PublicKeyToSPKI(ec2Key.x, ec2Key.y);
-
-      // Must be the raw authData bytes (not the parsed object) - the relying
-      // party server re-verifies this exact byte sequence against the signature.
-      const authenticatorData = extractRawAuthenticatorData(
-        attestationObjectBuffer
-      );
-
-      let authenticatorAttachment: AuthenticatorAttachment = "cross-platform";
-      if (
-        isPlatform &&
-        credential.attachment() ===
-          ASAuthorizationPublicKeyCredentialAttachment.Platform
-      ) {
-        authenticatorAttachment = "platform";
-      }
-
-      let isLargeBlobSupported: boolean | null = null;
-      if (enabledExtensions.includes("largeBlob")) {
-        const largeBlobOutput = credential.largeBlob();
-        if (largeBlobOutput) {
-          isLargeBlobSupported = largeBlobOutput.isSupported();
-        }
-      }
-
-      let prfFirst: Buffer | null = null;
-      let prfSecond: Buffer | null = null;
-      let isPRFSupported: boolean | null = null;
-      if (enabledExtensions.includes("prf")) {
-        const prfOutput = credential.prf();
-        if (prfOutput) {
-          const prfFirstData = prfOutput.first();
-          const prfSecondData = prfOutput.second();
-          if (prfFirstData) {
-            prfFirst = bufferFromNSDataDirect(prfFirstData);
-          }
-          if (prfSecondData) {
-            prfSecond = bufferFromNSDataDirect(prfSecondData);
-          }
-
-          isPRFSupported = prfOutput.isSupported();
-        }
-      }
-
-      const data: CreateCredentialResult = {
-        credentialId: credentialIdBuffer,
-        clientDataJSON: clientDataBuffer,
-        attestationObject: attestationObjectBuffer,
-        authenticatorData,
-        attachment: authenticatorAttachment,
-        transports: ["hybrid", "internal"],
-        isResidentKey: true,
-        publicKeyAlgorithm: publicKey.algorithm(),
-        publicKey: publicKeySPKI,
-        isLargeBlobSupported,
-        isPRFSupported,
-        prfFirst,
-        prfSecond,
-      };
-      resolve(data);
-
-      finished(true);
     },
     authorizationController$didCompleteWithError$: (_, error) => {
       reject(NativeError.fromNSError(error));

--- a/packages/macos/src/create/internal-handler.ts
+++ b/packages/macos/src/create/internal-handler.ts
@@ -2,6 +2,7 @@ import { generateClientDataInfo } from "../helpers/client-data.js";
 import { generateWebauthnClientData } from "../helpers/client-data.js";
 import { PromiseWithResolvers } from "../helpers/index.js";
 import { encodeEC2PublicKeyToSPKI } from "../helpers/public-key.js";
+import { extractRawAuthenticatorData } from "../helpers/attestation.js";
 import { createPresentationContextProviderFromNativeWindowHandle } from "../helpers/presentation.js";
 import { createPRFInput, type PRFInput } from "../helpers/prf.js";
 import {
@@ -383,8 +384,10 @@ function createCredentialInternal(
       const ec2Key = publicKey.ec2();
       const publicKeySPKI = encodeEC2PublicKeyToSPKI(ec2Key.x, ec2Key.y);
 
-      const authenticatorData = Buffer.from(
-        JSON.stringify(attestation.authenticatorData)
+      // Must be the raw authData bytes (not the parsed object) - the relying
+      // party server re-verifies this exact byte sequence against the signature.
+      const authenticatorData = extractRawAuthenticatorData(
+        attestationObjectBuffer
       );
 
       let authenticatorAttachment: AuthenticatorAttachment = "cross-platform";

--- a/packages/macos/src/create/internal-handler.ts
+++ b/packages/macos/src/create/internal-handler.ts
@@ -314,14 +314,6 @@ function createCredentialInternal(
   const { clientDataHash, clientDataBuffer } =
     generateClientDataInfo(clientData);
 
-  setControllerState(
-    authController,
-    clientDataHash,
-    supportedAlgorithmIdentifiers,
-    residentKeyRequired,
-    excludeCredentials
-  );
-
   let isFinished = false;
   let timeoutHandlerId: NodeJS.Timeout | null = null;
   const finished = (_success: boolean) => {
@@ -333,6 +325,23 @@ function createCredentialInternal(
       timeoutHandlerId = null;
     }
   };
+  const failConfiguration = (error: unknown) => {
+    if (isFinished) return;
+    reject(error instanceof Error ? error : new Error(String(error)));
+    finished(false);
+    try {
+      authController.cancel();
+    } catch {}
+  };
+
+  setControllerState(
+    authController,
+    clientDataHash,
+    supportedAlgorithmIdentifiers,
+    residentKeyRequired,
+    excludeCredentials,
+    failConfiguration
+  );
 
   // authController.delegate = self
   const delegate = createDelegate("ASAuthorizationControllerDelegate", {
@@ -449,7 +458,13 @@ function createCredentialInternal(
   authController.setPresentationContextProvider$(presentationContextProvider);
 
   // authController.performRequests()
-  authController.performRequests();
+  try {
+    authController.performRequests();
+  } catch (error) {
+    failConfiguration(error);
+  }
+
+  if (isFinished) return promise;
 
   // Cancelling auth controller on timeout
   timeoutHandlerId = setTimeout(() => {

--- a/packages/macos/src/create/internal-handler.ts
+++ b/packages/macos/src/create/internal-handler.ts
@@ -5,6 +5,7 @@ import { encodeEC2PublicKeyToSPKI } from "../helpers/public-key.js";
 import { extractRawAuthenticatorData } from "../helpers/attestation.js";
 import { createPresentationContextProviderFromNativeWindowHandle } from "../helpers/presentation.js";
 import { createPRFInput, type PRFInput } from "../helpers/prf.js";
+import { NativeError } from "../helpers/validation.js";
 import {
   removeControllerState,
   setControllerState,
@@ -446,10 +447,7 @@ function createCredentialInternal(
       finished(true);
     },
     authorizationController$didCompleteWithError$: (_, error) => {
-      const errorMessage = error.localizedDescription().UTF8String();
-      // console.error("Authorization failed:", errorMessage);
-
-      reject(new Error(errorMessage));
+      reject(NativeError.fromNSError(error));
       finished(false);
     },
   });
@@ -469,7 +467,7 @@ function createCredentialInternal(
 
   if (isFinished) return promise;
 
-  // Cancelling auth controller on timeout
+  // A ceremony timeout and user cancellation both map to WebAuthn's NotAllowedError.
   timeoutHandlerId = setTimeout(() => {
     if (isFinished) return;
     authController.cancel();

--- a/packages/macos/src/get/authorization-controller.ts
+++ b/packages/macos/src/get/authorization-controller.ts
@@ -2,15 +2,27 @@ import { NobjcClass, NobjcObject, getPointer } from "objc-js";
 import type { ASAuthorizationController } from "objcjs-types/AuthenticationServices";
 import { NSDataFromBuffer } from "objcjs-types/nsdata";
 
-const getControllerState = new Map<string, Buffer>();
+interface GetControllerState {
+  clientDataHash: Buffer;
+  onConfigurationError: (error: unknown) => void;
+}
+
+const getControllerState = new Map<string, GetControllerState>();
 
 function getObjectPointerString(self: NobjcObject) {
   return getPointer(self).toString("base64");
 }
 
-export function setClientDataHash(self: NobjcObject, clientDataHash: Buffer) {
+export function setClientDataHash(
+  self: NobjcObject,
+  clientDataHash: Buffer,
+  onConfigurationError: (error: unknown) => void
+) {
   const selfPointer = getObjectPointerString(self);
-  getControllerState.set(selfPointer, clientDataHash);
+  getControllerState.set(selfPointer, {
+    clientDataHash,
+    onConfigurationError,
+  });
 }
 
 export function removeClientDataHash(self: NobjcObject) {
@@ -22,7 +34,11 @@ export const WebauthnGetController = NobjcClass.define({
   name: "WebauthnGetController",
   superclass: "ASAuthorizationController",
   methods: {
-    // This overrides the default implementation of _requestContextWithRequests$error$ to allow us to set the clientDataHash on the assertion options
+    // Overrides _requestContextWithRequests$error$ to inject our clientDataHash into BOTH
+    // platform and security-key assertion options. Previously only the platform variant was
+    // mutated (with security-key used as a fallback), so security-key get requests signed
+    // a clientDataJSON that didn't match what we returned to the page and the relying party
+    // couldn't verify the assertion.
     _requestContextWithRequests$error$: {
       types: "@@:@^@",
       implementation: (self: any, requests: any, outError: any) => {
@@ -33,21 +49,39 @@ export const WebauthnGetController = NobjcClass.define({
           outError
         );
 
-        // Grab the assertion options, set the client data hash, and set a copy of the assertion options back on the context
         const selfPointer = getObjectPointerString(self);
-        if (getControllerState.has(selfPointer)) {
-          let assertionOptions =
-            context.platformKeyCredentialAssertionOptions();
-          if (!assertionOptions) {
-            assertionOptions = context.securityKeyCredentialAssertionOptions();
+        const state = getControllerState.get(selfPointer);
+        if (state) {
+          const { clientDataHash, onConfigurationError } = state;
+
+          try {
+            const platformOptions =
+              context.platformKeyCredentialAssertionOptions();
+            if (platformOptions) {
+              platformOptions.setClientDataHash$(
+                NSDataFromBuffer(clientDataHash)
+              );
+              context.setPlatformKeyCredentialAssertionOptions$(
+                platformOptions.copyWithZone$(null)
+              );
+            }
+
+            // Mirror on security-key options. These selectors are private, so fail the
+            // ceremony if either is unavailable rather than leaving an unpatched request
+            // active with a clientDataHash that does not match the returned clientDataJSON.
+            const securityKeyOptions =
+              context.securityKeyCredentialAssertionOptions();
+            if (securityKeyOptions) {
+              securityKeyOptions.setClientDataHash$(
+                NSDataFromBuffer(clientDataHash)
+              );
+              context.setSecurityKeyCredentialAssertionOptions$(
+                securityKeyOptions.copyWithZone$(null)
+              );
+            }
+          } catch (error) {
+            onConfigurationError(error);
           }
-
-          const clientDataHash = getControllerState.get(selfPointer);
-          assertionOptions.setClientDataHash$(NSDataFromBuffer(clientDataHash));
-
-          context.setPlatformKeyCredentialAssertionOptions$(
-            assertionOptions.copyWithZone$(null)
-          );
         }
 
         return context;

--- a/packages/macos/src/get/handler.ts
+++ b/packages/macos/src/get/handler.ts
@@ -106,7 +106,7 @@ export async function getCredential(
     // 1 hour (max timeout)
     timeout = 60 * 60 * 1000;
   }
-  // TODO: Handle timeout
+  // Timeout is enforced inside getCredentialInternal and surfaces as NotAllowedError.
 
   const challenge = bufferSourceToBuffer(publicKeyOptions.challenge);
   if (!challenge) {
@@ -167,10 +167,8 @@ export async function getCredential(
     }
   ).catch((error: Error) => {
     errorResult = error;
-    // console.error("Error getting credential", error);
-    if (error.message.startsWith("The operation couldn’t be completed.")) {
-      return "NotAllowedError";
-    }
+    // get() has no InvalidStateError. Native failures, including ceremony timeout and
+    // user cancellation, surface as NotAllowedError.
     return "NotAllowedError" as const;
   });
 

--- a/packages/macos/src/get/handler.ts
+++ b/packages/macos/src/get/handler.ts
@@ -90,7 +90,7 @@ export async function getCredential(
 ): Promise<GetCredentialResult> {
   // Check all the arguments
   if (!publicKeyOptions) {
-    return null;
+    return { success: false, error: "TypeError" };
   }
 
   const rpId = publicKeyOptions.rpId;
@@ -179,6 +179,7 @@ export async function getCredential(
 
   const data: GetCredentialSuccessData = {
     credentialId: bufferToBase64Url(result.id),
+    authenticatorAttachment: result.authenticatorAttachment,
     clientDataJSON: bufferToBase64Url(result.clientDataJSON),
     authenticatorData: bufferToBase64Url(result.authenticatorData),
     signature: bufferToBase64Url(result.signature),
@@ -188,17 +189,18 @@ export async function getCredential(
 
   // Add PRF extension results if available
   if (result.prf && (result.prf[0] || result.prf[1])) {
-    data.extensions!.prf = {
+    data.extensions.prf = {
       results: {
-        first: bufferToBase64Url(result.prf[0]!),
+        first: result.prf[0] ? bufferToBase64Url(result.prf[0]) : undefined,
         second: result.prf[1] ? bufferToBase64Url(result.prf[1]) : undefined,
       },
     };
   }
 
   // Add largeBlob extension results if available
-  if (result.largeBlob || result.largeBlobWritten) {
-    data.extensions!.largeBlob = {
+  if (result.largeBlob || result.largeBlobWritten !== null) {
+    // `false` is a meaningful failed-write result, not "extension absent".
+    data.extensions.largeBlob = {
       blob: result.largeBlob ? bufferToBase64Url(result.largeBlob) : undefined,
       written:
         result.largeBlobWritten !== null ? result.largeBlobWritten : undefined,

--- a/packages/macos/src/get/internal-handler.ts
+++ b/packages/macos/src/get/internal-handler.ts
@@ -18,6 +18,7 @@ import {
   ASAuthorizationPublicKeyCredentialLargeBlobAssertionInput,
   ASAuthorizationPublicKeyCredentialLargeBlobAssertionOperation,
   ASAuthorizationPlatformPublicKeyCredentialDescriptor,
+  ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor,
   ASAuthorizationSecurityKeyPublicKeyCredentialProvider,
   ASAuthorizationPublicKeyCredentialPRFAssertionInput,
   ASAuthorizationPublicKeyCredentialAttachment,
@@ -281,16 +282,28 @@ function getCredentialInternal(
 
   setClientDataHash(authController, clientDataHash, failConfiguration);
 
-  // Set allowed credentials if provided
+  // Set allowed credentials if provided. Must be set on both requests - only setting it
+  // on platformKeyRequest left the security-key request unrestricted, letting any resident
+  // credential on the key be used even when the RP only allow-listed specific credential IDs.
   if (allowedCredentialIds.length > 0) {
-    const allowedCredentials = NSArrayFromObjects(
+    const allowedPlatformCredentials = NSArrayFromObjects(
       allowedCredentialIds.map((id) =>
         ASAuthorizationPlatformPublicKeyCredentialDescriptor.alloc().initWithCredentialID$(
           NSDataFromBuffer(id)
         )
       )
     );
-    platformKeyRequest.setAllowedCredentials$(allowedCredentials);
+    platformKeyRequest.setAllowedCredentials$(allowedPlatformCredentials);
+
+    const allowedSecurityKeyCredentials = NSArrayFromObjects(
+      allowedCredentialIds.map((id) =>
+        ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor.alloc().initWithCredentialID$transports$(
+          NSDataFromBuffer(id),
+          NSArrayFromObjects([])
+        )
+      )
+    );
+    securityKeyRequest.setAllowedCredentials$(allowedSecurityKeyCredentials);
   }
 
   // authController.delegate = self
@@ -299,70 +312,78 @@ function getCredentialInternal(
       _,
       authorization
     ) => {
-      const credential = authorization.credential();
-      // console.log("Authorization succeeded:", credential);
+      // Wrapped in try/catch: without this, an unexpected error below would leave the
+      // returned promise pending forever, since neither resolve/reject nor finished()
+      // would otherwise run.
+      try {
+        const credential = authorization.credential();
 
-      const isPlatform =
-        credential instanceof
-        ASAuthorizationPlatformPublicKeyCredentialAssertion;
-      const isSecurityKey =
-        credential instanceof
-        ASAuthorizationSecurityKeyPublicKeyCredentialAssertion;
-      if (!isPlatform && !isSecurityKey) {
-        reject(
-          new Error(
-            "Resulting credential is not a platform or security key credential"
-          )
-        );
-        finished(false);
-        return;
-      }
-
-      const id_data = credential.credentialID();
-      const id = bufferFromNSDataDirect(id_data);
-
-      let authenticatorAttachment: AuthenticatorAttachment = "cross-platform";
-      if (
-        isPlatform &&
-        credential.attachment() ===
-          ASAuthorizationPublicKeyCredentialAttachment.Platform
-      ) {
-        authenticatorAttachment = "platform";
-      }
-
-      const prf = credential.prf();
-      const prfFirst = prf?.first ? prf.first() : null;
-      const prfSecond = prf?.second ? prf.second() : null;
-
-      let largeBlobBuffer: Buffer | null = null;
-      let largeBlobWritten: boolean | null = null;
-      if (credential.largeBlob()) {
-        const largeBlobData = credential.largeBlob().readData();
-        if (largeBlobData) {
-          largeBlobBuffer = bufferFromNSDataDirect(largeBlobData);
-        } else {
-          largeBlobWritten = credential.largeBlob().didWrite();
+        const isPlatform =
+          credential instanceof
+          ASAuthorizationPlatformPublicKeyCredentialAssertion;
+        const isSecurityKey =
+          credential instanceof
+          ASAuthorizationSecurityKeyPublicKeyCredentialAssertion;
+        if (!isPlatform && !isSecurityKey) {
+          reject(
+            new Error(
+              "Resulting credential is not a platform or security key credential"
+            )
+          );
+          finished(false);
+          return;
         }
+
+        const id_data = credential.credentialID();
+        const id = bufferFromNSDataDirect(id_data);
+
+        let authenticatorAttachment: AuthenticatorAttachment =
+          "cross-platform";
+        if (
+          isPlatform &&
+          credential.attachment() ===
+            ASAuthorizationPublicKeyCredentialAttachment.Platform
+        ) {
+          authenticatorAttachment = "platform";
+        }
+
+        const prf = credential.prf();
+        const prfFirst = prf?.first ? prf.first() : null;
+        const prfSecond = prf?.second ? prf.second() : null;
+
+        let largeBlobBuffer: Buffer | null = null;
+        let largeBlobWritten: boolean | null = null;
+        if (credential.largeBlob()) {
+          const largeBlobData = credential.largeBlob().readData();
+          if (largeBlobData) {
+            largeBlobBuffer = bufferFromNSDataDirect(largeBlobData);
+          } else {
+            largeBlobWritten = credential.largeBlob().didWrite();
+          }
+        }
+
+        resolve({
+          id,
+          authenticatorAttachment,
+          clientDataJSON: clientDataBuffer, //bufferFromNSDataDirect(credential.rawClientDataJSON()),
+          authenticatorData: bufferFromNSDataDirect(
+            credential.rawAuthenticatorData()
+          ),
+          signature: bufferFromNSDataDirect(credential.signature()),
+          userHandle: bufferFromNSDataDirect(credential.userID()),
+          prf: [
+            prfFirst ? bufferFromNSDataDirect(prfFirst) : null,
+            prfSecond ? bufferFromNSDataDirect(prfSecond) : null,
+          ],
+          largeBlob: largeBlobBuffer,
+          largeBlobWritten,
+        });
+
+        finished(true);
+      } catch (error) {
+        reject(error instanceof Error ? error : new Error(String(error)));
+        finished(false);
       }
-
-      resolve({
-        id,
-        authenticatorAttachment,
-        clientDataJSON: clientDataBuffer, //bufferFromNSDataDirect(credential.rawClientDataJSON()),
-        authenticatorData: bufferFromNSDataDirect(
-          credential.rawAuthenticatorData()
-        ),
-        signature: bufferFromNSDataDirect(credential.signature()),
-        userHandle: bufferFromNSDataDirect(credential.userID()),
-        prf: [
-          prfFirst ? bufferFromNSDataDirect(prfFirst) : null,
-          prfSecond ? bufferFromNSDataDirect(prfSecond) : null,
-        ],
-        largeBlob: largeBlobBuffer,
-        largeBlobWritten,
-      });
-
-      finished(true);
     },
     authorizationController$didCompleteWithError$: (_, error) => {
       reject(NativeError.fromNSError(error));

--- a/packages/macos/src/get/internal-handler.ts
+++ b/packages/macos/src/get/internal-handler.ts
@@ -258,8 +258,6 @@ function getCredentialInternal(
   const { clientDataHash, clientDataBuffer } =
     generateClientDataInfo(clientData);
 
-  setClientDataHash(authController, clientDataHash);
-
   let isFinished = false;
   let timeoutHandlerId: NodeJS.Timeout | null = null;
   const finished = (_success: boolean) => {
@@ -271,6 +269,16 @@ function getCredentialInternal(
       timeoutHandlerId = null;
     }
   };
+  const failConfiguration = (error: unknown) => {
+    if (isFinished) return;
+    reject(error instanceof Error ? error : new Error(String(error)));
+    finished(false);
+    try {
+      authController.cancel();
+    } catch {}
+  };
+
+  setClientDataHash(authController, clientDataHash, failConfiguration);
 
   // Set allowed credentials if provided
   if (allowedCredentialIds.length > 0) {
@@ -373,7 +381,13 @@ function getCredentialInternal(
   authController.setPresentationContextProvider$(presentationContextProvider);
 
   // authController.performRequests()
-  authController.performRequests();
+  try {
+    authController.performRequests();
+  } catch (error) {
+    failConfiguration(error);
+  }
+
+  if (isFinished) return promise;
 
   // Cancelling auth controller on timeout
   timeoutHandlerId = setTimeout(() => {

--- a/packages/macos/src/get/internal-handler.ts
+++ b/packages/macos/src/get/internal-handler.ts
@@ -11,6 +11,7 @@ import {
 } from "../helpers/client-data.js";
 import { createPresentationContextProviderFromNativeWindowHandle } from "../helpers/presentation.js";
 import type { AuthenticatorAttachment } from "../helpers/types.js";
+import { NativeError } from "../helpers/validation.js";
 import { NSStringFromString } from "objcjs-types/helpers";
 import {
   ASAuthorizationPlatformPublicKeyCredentialProvider,
@@ -364,10 +365,7 @@ function getCredentialInternal(
       finished(true);
     },
     authorizationController$didCompleteWithError$: (_, error) => {
-      const errorMessage = error.localizedDescription().UTF8String();
-      // console.error("Authorization failed:", errorMessage);
-
-      reject(new Error(errorMessage));
+      reject(NativeError.fromNSError(error));
       finished(false);
     },
   });
@@ -389,7 +387,7 @@ function getCredentialInternal(
 
   if (isFinished) return promise;
 
-  // Cancelling auth controller on timeout
+  // A ceremony timeout and user cancellation both map to WebAuthn's NotAllowedError.
   timeoutHandlerId = setTimeout(() => {
     if (isFinished) return;
     authController.cancel();

--- a/packages/macos/src/helpers/attestation.ts
+++ b/packages/macos/src/helpers/attestation.ts
@@ -1,0 +1,45 @@
+import {
+  CBORByteString,
+  CBORMap,
+  CBORTextString,
+  decodeCBORNoLeftoverBytes,
+} from "@oslojs/cbor";
+
+/**
+ * Extract the raw `authData` bytes from a CBOR-encoded attestation object.
+ *
+ * `@oslojs/webauthn`'s `parseAttestationObject` only exposes the *parsed*
+ * authenticator data fields (no raw byte access), but the WebAuthn spec
+ * requires returning the original authData bytes to the caller (they are
+ * fed back into signature/hash verification on the relying party server).
+ *
+ * Note: we can't use `CBORMap.get()` here - `@oslojs/cbor` compares
+ * `CBORTextString` keys by reference (`===` on the underlying Uint8Array),
+ * so a freshly-constructed lookup key never matches a decoded one.
+ */
+export function extractRawAuthenticatorData(
+  attestationObjectBuffer: Buffer
+): Buffer {
+  const decoded = decodeCBORNoLeftoverBytes(
+    new Uint8Array(attestationObjectBuffer),
+    16
+  );
+  if (!(decoded instanceof CBORMap)) {
+    throw new Error(
+      "Invalid attestation object: expected a top-level CBOR map"
+    );
+  }
+
+  for (const [key, value] of decoded.entries) {
+    if (key instanceof CBORTextString && key.decodeText() === "authData") {
+      if (!(value instanceof CBORByteString)) {
+        throw new Error(
+          "Invalid attestation object: 'authData' is not a byte string"
+        );
+      }
+      return Buffer.from(value.value);
+    }
+  }
+
+  throw new Error("Invalid attestation object: missing 'authData' field");
+}

--- a/packages/macos/src/helpers/validation.ts
+++ b/packages/macos/src/helpers/validation.ts
@@ -1,9 +1,9 @@
 export function isString(value: unknown): value is string {
-  return value && typeof value === "string";
+  return typeof value === "string";
 }
 
 export function isNumber(value: unknown): value is number {
-  return value && typeof value === "number";
+  return typeof value === "number" && Number.isFinite(value);
 }
 
 export function isObject(value: unknown) {

--- a/packages/macos/src/helpers/validation.ts
+++ b/packages/macos/src/helpers/validation.ts
@@ -9,3 +9,78 @@ export function isNumber(value: unknown): value is number {
 export function isObject(value: unknown) {
   return value && typeof value === "object";
 }
+
+const AUTHORIZATION_ERROR_DOMAIN =
+  "com.apple.AuthenticationServices.AuthorizationError";
+
+/** Minimal NSError surface used by ASAuthorizationController delegates. */
+interface NSErrorLike {
+  localizedDescription(): { UTF8String(): string };
+  code(): number;
+  domain(): { UTF8String(): string };
+}
+
+/**
+ * JS Error carrying NSError code/domain. Those fields are not localized, so
+ * callers can map AuthorizationError without matching English message text.
+ */
+export class NativeError extends Error {
+  readonly code?: number;
+  readonly domain?: string;
+
+  constructor(
+    message: string,
+    options?: {
+      code?: number;
+      domain?: string;
+    }
+  ) {
+    super(message);
+    this.name = "NativeError";
+    this.code = options?.code;
+    this.domain = options?.domain;
+  }
+
+  static fromNSError(error: NSErrorLike): NativeError {
+    const message = error.localizedDescription().UTF8String();
+    try {
+      return new NativeError(message, {
+        code: error.code(),
+        domain: error.domain().UTF8String(),
+      });
+    } catch {
+      return new NativeError(message);
+    }
+  }
+}
+
+export function mapNativeAuthorizationError(
+  error: unknown
+): "InvalidStateError" | "NotAllowedError" {
+  // Prefer NSError code/domain from authorizationController delegates (never localized).
+  if (
+    error instanceof NativeError &&
+    error.domain === AUTHORIZATION_ERROR_DOMAIN &&
+    typeof error.code === "number"
+  ) {
+    return error.code === 1006 ? "InvalidStateError" : "NotAllowedError";
+  }
+
+  // Fallback: domain name and numeric code survive localization in NSError descriptions.
+  const msg =
+    error instanceof Error
+      ? error.message
+      : typeof error === "object" &&
+          error !== null &&
+          "message" in error &&
+          typeof (error as { message: unknown }).message === "string"
+        ? (error as { message: string }).message
+        : "";
+  const match = msg.match(/AuthorizationError\D{0,20}?(\d+)/);
+  const code = match ? Number(match[1]) : null;
+  if (code === 1006) {
+    // ASAuthorizationError.matchedExcludedCredential (create excludeCredentials only).
+    return "InvalidStateError";
+  }
+  return "NotAllowedError";
+}

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -6,14 +6,15 @@ export type GetCredentialErrorCodes =
 
 export interface GetCredentialSuccessData {
   credentialId: string;
+  authenticatorAttachment: AuthenticatorAttachment;
   clientDataJSON: string;
   authenticatorData: string;
   signature: string;
   userHandle: string;
-  extensions?: {
+  extensions: {
     prf?: {
-      results?: {
-        first: string;
+      results: {
+        first?: string;
         second?: string;
       };
     };
@@ -48,25 +49,27 @@ export type CreateCredentialErrorCodes =
 
 export interface CreateCredentialSuccessData {
   credentialId: string;
+  authenticatorAttachment: AuthenticatorAttachment;
   clientDataJSON: string;
   attestationObject: string;
   authData: string;
   publicKey: string;
   publicKeyAlgorithm: number;
-  transports: string[];
+  transports: AuthenticatorTransport[];
   extensions: {
     credProps?: {
       rk: boolean;
     };
     prf?: {
-      enabled?: boolean;
+      // `enabled` is an electron-webauthn extension (W3C AuthenticationExtensionsPRFOutputs only has `results`): signals PRF capability on the created credential.
+      enabled: boolean;
       results: {
         first?: string;
         second?: string;
       };
     };
     largeBlob?: {
-      supported?: boolean;
+      supported: boolean;
     };
   };
 }

--- a/test/attestation.test.ts
+++ b/test/attestation.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { extractRawAuthenticatorData } from "../packages/macos/src/helpers/attestation";
+
+// Hand-crafted minimal CBOR-encoded attestation object:
+// { "fmt": "none", "attStmt": {}, "authData": <4 raw bytes> }
+function buildAttestationObject(authData: number[]): Buffer {
+  return Buffer.from([
+    0xa3, // map(3)
+    0x63,
+    0x66,
+    0x6d,
+    0x74, // "fmt"
+    0x64,
+    0x6e,
+    0x6f,
+    0x6e,
+    0x65, // "none"
+    0x67,
+    0x61,
+    0x74,
+    0x74,
+    0x53,
+    0x74,
+    0x6d,
+    0x74, // "attStmt"
+    0xa0, // {}
+    0x68,
+    0x61,
+    0x75,
+    0x74,
+    0x68,
+    0x44,
+    0x61,
+    0x74,
+    0x61, // "authData"
+    0x40 + authData.length, // byte string(len)
+    ...authData,
+  ]);
+}
+
+describe("extractRawAuthenticatorData", () => {
+  test("extracts the exact authData bytes from a CBOR attestation object", () => {
+    const attestationObject = buildAttestationObject([0xde, 0xad, 0xbe, 0xef]);
+
+    const result = extractRawAuthenticatorData(attestationObject);
+
+    expect(result).toEqual(Buffer.from([0xde, 0xad, 0xbe, 0xef]));
+  });
+
+  test("throws on a non-map top-level CBOR value", () => {
+    // A bare CBOR text string "hello" instead of a map.
+    const notAMap = Buffer.from([0x65, 0x68, 0x65, 0x6c, 0x6c, 0x6f]);
+
+    expect(() => extractRawAuthenticatorData(notAMap)).toThrow();
+  });
+
+  test("throws when authData is missing", () => {
+    const attestationObject = Buffer.from([
+      0xa1, // map(1)
+      0x63,
+      0x66,
+      0x6d,
+      0x74, // "fmt"
+      0x64,
+      0x6e,
+      0x6f,
+      0x6e,
+      0x65, // "none"
+    ]);
+
+    expect(() => extractRawAuthenticatorData(attestationObject)).toThrow();
+  });
+});

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isNumber,
+  isString,
   mapNativeAuthorizationError,
   NativeError,
 } from "../packages/macos/src/helpers/validation";
@@ -7,8 +9,23 @@ import {
 const AUTHORIZATION_ERROR_DOMAIN =
   "com.apple.AuthenticationServices.AuthorizationError";
 
-describe("mapNativeAuthorizationError", () => {
-  test("uses NativeError code/domain", () => {
+describe("validation helpers", () => {
+  test("isString accepts empty string", () => {
+    expect(isString("")).toBe(true);
+    expect(isString("rp.example")).toBe(true);
+    expect(isString(null)).toBe(false);
+    expect(isString(undefined)).toBe(false);
+  });
+
+  test("isNumber rejects non-finite numbers", () => {
+    expect(isNumber(0)).toBe(true);
+    expect(isNumber(1000)).toBe(true);
+    expect(isNumber(NaN)).toBe(false);
+    expect(isNumber(Infinity)).toBe(false);
+    expect(isNumber(null)).toBe(false);
+  });
+
+  test("mapNativeAuthorizationError uses NativeError code/domain", () => {
     expect(
       mapNativeAuthorizationError(
         new NativeError("excluded", {
@@ -28,7 +45,7 @@ describe("mapNativeAuthorizationError", () => {
     ).toBe("NotAllowedError");
   });
 
-  test("parses English NSError descriptions", () => {
+  test("mapNativeAuthorizationError parses English NSError descriptions", () => {
     expect(
       mapNativeAuthorizationError(
         new Error(
@@ -46,7 +63,7 @@ describe("mapNativeAuthorizationError", () => {
     ).toBe("NotAllowedError");
   });
 
-  test("parses localized NSError descriptions", () => {
+  test("mapNativeAuthorizationError parses localized NSError descriptions", () => {
     expect(
       mapNativeAuthorizationError(
         new Error(
@@ -64,14 +81,14 @@ describe("mapNativeAuthorizationError", () => {
     ).toBe("NotAllowedError");
   });
 
-  test("defaults to NotAllowedError", () => {
+  test("mapNativeAuthorizationError defaults to NotAllowedError", () => {
     expect(mapNativeAuthorizationError(new Error("unknown failure"))).toBe(
       "NotAllowedError"
     );
     expect(mapNativeAuthorizationError({})).toBe("NotAllowedError");
   });
 
-  test("maps cancellation to NotAllowedError", () => {
+  test("mapNativeAuthorizationError maps cancellation to NotAllowedError", () => {
     expect(
       mapNativeAuthorizationError(
         new NativeError("cancelled", {

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+import {
+  mapNativeAuthorizationError,
+  NativeError,
+} from "../packages/macos/src/helpers/validation";
+
+const AUTHORIZATION_ERROR_DOMAIN =
+  "com.apple.AuthenticationServices.AuthorizationError";
+
+describe("mapNativeAuthorizationError", () => {
+  test("uses NativeError code/domain", () => {
+    expect(
+      mapNativeAuthorizationError(
+        new NativeError("excluded", {
+          domain: AUTHORIZATION_ERROR_DOMAIN,
+          code: 1006,
+        })
+      )
+    ).toBe("InvalidStateError");
+
+    expect(
+      mapNativeAuthorizationError(
+        new NativeError("cancelled", {
+          domain: AUTHORIZATION_ERROR_DOMAIN,
+          code: 1001,
+        })
+      )
+    ).toBe("NotAllowedError");
+  });
+
+  test("parses English NSError descriptions", () => {
+    expect(
+      mapNativeAuthorizationError(
+        new Error(
+          "The operation couldn't be completed. (com.apple.AuthenticationServices.AuthorizationError error 1006.)"
+        )
+      )
+    ).toBe("InvalidStateError");
+
+    expect(
+      mapNativeAuthorizationError(
+        new Error(
+          "The operation couldn't be completed. (com.apple.AuthenticationServices.AuthorizationError error 1001.)"
+        )
+      )
+    ).toBe("NotAllowedError");
+  });
+
+  test("parses localized NSError descriptions", () => {
+    expect(
+      mapNativeAuthorizationError(
+        new Error(
+          "操作无法完成。（com.apple.AuthenticationServices.AuthorizationError错误1006。）"
+        )
+      )
+    ).toBe("InvalidStateError");
+
+    expect(
+      mapNativeAuthorizationError(
+        new Error(
+          "操作无法完成。（com.apple.AuthenticationServices.AuthorizationError错误1001。）"
+        )
+      )
+    ).toBe("NotAllowedError");
+  });
+
+  test("defaults to NotAllowedError", () => {
+    expect(mapNativeAuthorizationError(new Error("unknown failure"))).toBe(
+      "NotAllowedError"
+    );
+    expect(mapNativeAuthorizationError({})).toBe("NotAllowedError");
+  });
+
+  test("maps cancellation to NotAllowedError", () => {
+    expect(
+      mapNativeAuthorizationError(
+        new NativeError("cancelled", {
+          domain: AUTHORIZATION_ERROR_DOMAIN,
+          code: 1001,
+        })
+      )
+    ).toBe("NotAllowedError");
+  });
+});


### PR DESCRIPTION
Fixes several correctness bugs in the macOS ASAuthorizationController bridge, uncovered while integrating with an Electron app that ships security keys (YubiKey) alongside Touch ID. Each one breaks relying-party verification or deviates from the WebAuthn spec.

### clientDataHash on security keys (create + get)
When `authenticatorAttachment: "all"`, we submit both platform and security-key requests. `_requestContextWithRequests:error:` used to only patch whichever options object it found first — platform wins, security-key is fallback. So the security-key path kept Apple's default `clientDataHash`, signed the wrong `clientDataJSON`, and the RP couldn't verify the result.
Now both option sets get the hash. On create, security-key options also get `pubKeyCredParams`, resident-key, and `excludeCredentials` via the same `applyCreateOptions` path.
Security-key setters are private and may be absent on older macOS. Platform + security-key mutation is wrapped in one try/catch with `onConfigurationError` / `failConfiguration`: if configuration fails, the ceremony fails closed (reject + `cancel()`) rather than leaving a partially patched security-key request active. `performRequests()` is similarly wrapped.

### Raw authData on create
`createCredential().data.authData` was `JSON.stringify()` of the parsed object. RPs need the raw CBOR bytes from inside the attestation object. Added `extractRawAuthenticatorData()` — decode the CBOR map, pull `authData` out.

### Error mapping on non-English macOS
Matching `"The operation couldn't be completed."` doesn't work on Chinese (etc.) systems. Delegates now attach `NSError.code()` / `domain()` — those don't localize. `mapNativeAuthorizationError` uses those first, regex on the message as fallback. 1006 → `InvalidStateError`, everything else → `NotAllowedError`.
Ceremony timeout and user cancellation both surface as `NotAllowedError` (an earlier AbortError mapping for self-initiated timeouts was dropped).

### PRF null guard
`get()` used `bufferToBase64Url(result.prf[0]!)` while the internal handler already models both PRF slots as nullable. Both `first` and `second` are now conditional.

### authenticatorAttachment
Native side already knew platform vs cross-platform; we just weren't returning it. Added to both success payloads.

### transports
Was hardcoded `["hybrid", "internal"]` for everything. Touch ID should only report `["internal"]`. Now `["internal"]` for platform, `[]` for security keys (macOS doesn't expose their transport here).

### `return null` on missing options
`createCredential` / `getCredential` returned `null` when `publicKeyOptions` was missing. Not in the result union (`strictNullChecks: false` hid it). Callers doing `result.success` get a raw TypeError. Returns `{ success: false, error: "TypeError" }` now.

### Other small stuff
- `largeBlobWritten`: `!== null` so a failed write (`false`) isn't dropped
- `isString` accepts `""`; `isNumber` rejects NaN/Infinity
- Success delegates in `try/catch` so a parse error doesn't leave the promise hanging
- Types tightened: optional `first` on get PRF, `AuthenticatorTransport[]`, required `extensions` / `enabled` / `supported` where we always set them
- `peerDependencies.typescript` `^6.0.2` → `^5.0.0` optional — only need TS 5 for `export type *`, was blocking TS 5.x consumers
- `@oslojs/cbor` dep, `bun.lock` regen, tests for validation + attestation helpers